### PR TITLE
change output to individual outputs instead of collections

### DIFF
--- a/tools/falco/falco.xml
+++ b/tools/falco/falco.xml
@@ -289,7 +289,7 @@
             <output name="text_file" file="fastqc_report_reverse_complement.txt" ftype="txt" lines_diff="2"/>
         </test>
         <!-- Test summary file option paired input -->
-        <test expect_num_outputs="9">
+        <test expect_num_outputs="6">
             <conditional name="input_type_select">
                 <param name="input_type" value="paired"/>
                 <param name="input_col">

--- a/tools/falco/falco.xml
+++ b/tools/falco/falco.xml
@@ -107,21 +107,24 @@
         <data format="txt" name="summary_file" from_work_dir="summary.txt" label="${tool.name} on ${on_string}: SummaryData">
             <filter>input_type_select['input_type'] == 'individually' and generate_summary</filter>
         </data>
-        <collection name="html_files" format="html" type="paired" label="${tool.name} on ${on_string}: Webpages">
-            <data name="forward" from_work_dir="*forward_fastqc_report.html" />
-            <data name="reverse" from_work_dir="*reverse_fastqc_report.html" />
+        <data format="html" name="html_file_forward" from_work_dir="*forward_fastqc_report.html" label="${tool.name} on ${on_string}: Webpage forward" >
             <filter>input_type_select['input_type'] == 'paired'</filter>
-        </collection>
-        <collection name="text_files" format="txt" type="paired" label="${tool.name} on ${on_string}: RawData text files">
-            <data name="forward" from_work_dir="*forward_fastqc_data.txt" />
-            <data name="reverse" from_work_dir="*reverse_fastqc_data.txt" />
+        </data>
+        <data format="txt" name="text_file_forward" from_work_dir="*forward_fastqc_data.txt" label="${tool.name} on ${on_string}: RawData forward" >
             <filter>input_type_select['input_type'] == 'paired'</filter>
-        </collection>
-        <collection name="summary_files" format="txt" type="paired" label="${tool.name} on ${on_string}: SummaryData text files">
-            <data name="forward" from_work_dir="*forward_summary.txt" />
-            <data name="reverse" from_work_dir="*reverse_summary.txt" />
+        </data>
+        <data format="txt" name="summary_file_forward" from_work_dir="*forward_summary.txt" label="${tool.name} on ${on_string}: SummaryData forward">
             <filter>input_type_select['input_type'] == 'paired' and generate_summary</filter>
-        </collection>
+        </data>
+        <data format="html" name="html_file_reverse" from_work_dir="*reverse_fastqc_report.html" label="${tool.name} on ${on_string}: Webpage reverse" >
+            <filter>input_type_select['input_type'] == 'paired'</filter>
+        </data>
+        <data format="txt" name="text_file_reverse" from_work_dir="*reverse_fastqc_data.txt" label="${tool.name} on ${on_string}: RawData reverse" >
+            <filter>input_type_select['input_type'] == 'paired'</filter>
+        </data>
+        <data format="txt" name="summary_file_reverse" from_work_dir="*reverse_summary.txt" label="${tool.name} on ${on_string}: SummaryData reverse">
+            <filter>input_type_select['input_type'] == 'paired' and generate_summary</filter>
+        </data>
     </outputs>
     <tests>
         <!-- Test with fastq input -->
@@ -297,40 +300,34 @@
                 </param>
             </conditional>
             <param name="generate_summary" value="true"/>
-            <output_collection name="html_files">
-                <element name="forward">
-                    <assert_contents>
-                        <has_line_matching expression="&lt;html&gt;&lt;head&gt;.+&lt;title&gt;     1000trimmed_forward - report.+"/>
-                    </assert_contents>
-                </element>
-                <element name="reverse">
-                    <assert_contents>
-                        <has_line_matching expression="&lt;html&gt;&lt;head&gt;.+&lt;title&gt;     1000trimmed_reverse - report.+"/>
-                    </assert_contents>
-                </element>
-            </output_collection>
-            <output_collection name="text_files">
-                <element name="forward" value="forward_fastqc_data.txt" />
-                <element name="reverse">
-                    <assert_contents>
-                    <has_text text="1000trimmed_reverse" />
-                    </assert_contents>
-                </element>
-            </output_collection>
-            <output_collection name="summary_files">
-                <element name="forward">
-                    <assert_contents>
-                    <has_text text="1000trimmed_forward" />
-                    <has_n_lines n="11" />
-                    </assert_contents>
-                </element>
-                <element name="reverse">
-                    <assert_contents>
-                    <has_text text="1000trimmed_reverse" />
-                    <has_n_lines n="11" />
-                    </assert_contents>
-                </element>
-            </output_collection>
+            <output name="html_file_forward">
+                <assert_contents>
+                    <has_line_matching expression="&lt;html&gt;&lt;head&gt;.+&lt;title&gt;     1000trimmed_forward - report.+"/>
+                </assert_contents>
+            </output>
+            <output name="html_file_reverse">
+                <assert_contents>
+                    <has_line_matching expression="&lt;html&gt;&lt;head&gt;.+&lt;title&gt;     1000trimmed_reverse - report.+"/>
+                </assert_contents>
+            </output>
+            <output name="text_file_forward" value="forward_fastqc_data.txt" />
+            <output name="text_file_reverse">
+                <assert_contents>
+                <has_text text="1000trimmed_reverse" />
+                </assert_contents>
+            </output>
+            <output name="summary_file_forward">
+                <assert_contents>
+                <has_text text="1000trimmed_forward" />
+                <has_n_lines n="11" />
+                </assert_contents>
+            </output>
+            <output name="summary_file_reverse">
+                <assert_contents>
+                <has_text text="1000trimmed_reverse" />
+                <has_n_lines n="11" />
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/fastqc/rgFastQC.xml
+++ b/tools/fastqc/rgFastQC.xml
@@ -218,7 +218,7 @@
             <output name="html_file" file="fastqc_report_hisat.html" ftype="html" lines_diff="2"/>
             <output name="text_file" file="fastqc_data_hisat.txt" ftype="txt"/>
         </test>
-        <test expect_num_outputs="6">
+        <test expect_num_outputs="4">
             <conditional name="input_type_select">
                 <param name="input_type" value="paired"/>
                 <param name="input_col">

--- a/tools/fastqc/rgFastQC.xml
+++ b/tools/fastqc/rgFastQC.xml
@@ -87,12 +87,16 @@
             && mkdir ${html_file.files_path}
             && cp -r 'out_dir'/*/Images ${html_file.files_path}/
         #else
-            #for $suffix in ['forward', 'reverse']
-                && cp 'out_dir'/*'${suffix}'_fastqc/fastqc_data.txt 'output_${suffix}.txt'
-                && cp 'out_dir'/*'${suffix}'_fastqc/fastqc_report.html 'output_${suffix}.html'
-                && mkdir ${html_files[$suffix].files_path}
-                && cp -r 'out_dir'/*'${suffix}'_fastqc/Images ${html_files[$suffix].files_path}/
-            #end for
+            #set suffix='forward'
+            && cp 'out_dir'/*'${suffix}'_fastqc/fastqc_data.txt 'output_${suffix}.txt'
+            && cp 'out_dir'/*'${suffix}'_fastqc/fastqc_report.html 'output_${suffix}.html'
+            && mkdir ${html_file_forward.files_path}
+            && cp -r 'out_dir'/*'${suffix}'_fastqc/Images ${html_file_forward.files_path}/
+            #set suffix='reverse'
+            && cp 'out_dir'/*'${suffix}'_fastqc/fastqc_data.txt 'output_${suffix}.txt'
+            && cp 'out_dir'/*'${suffix}'_fastqc/fastqc_report.html 'output_${suffix}.html'
+            && mkdir ${html_file_reverse.files_path}
+            && cp -r 'out_dir'/*'${suffix}'_fastqc/Images ${html_file_reverse.files_path}/
         #end if
     ]]></command>
     <inputs>
@@ -131,16 +135,18 @@
         <data format="txt" name="text_file"  from_work_dir="output.txt" label="${tool.name} on ${on_string}: RawData" >
             <filter>input_type_select['input_type'] == 'individually'</filter>
         </data>
-        <collection name="html_files" format="html" type="paired" label="${tool.name} on ${on_string}: Webpages">
-            <data name="forward" from_work_dir="output_forward.html" />
-            <data name="reverse" from_work_dir="output_reverse.html" />
+        <data format="html" name="html_file_forward" from_work_dir="output_forward.html" label="${tool.name} on ${on_string}: Webpage forward" >
             <filter>input_type_select['input_type'] == 'paired'</filter>
-        </collection>
-        <collection name="text_files" format="txt" type="paired" label="${tool.name} on ${on_string}: RawData text files">
-            <data name="forward" from_work_dir="output_forward.txt" />
-            <data name="reverse" from_work_dir="output_reverse.txt" />
+        </data>
+        <data format="txt" name="text_file_forward"  from_work_dir="output_forward.txt" label="${tool.name} on ${on_string}: RawData forward" >
             <filter>input_type_select['input_type'] == 'paired'</filter>
-        </collection>
+        </data>
+        <data format="html" name="html_file_reverse" from_work_dir="output_reverse.html" label="${tool.name} on ${on_string}: Webpage reverse" >
+            <filter>input_type_select['input_type'] == 'paired'</filter>
+        </data>
+        <data format="txt" name="text_file_reverse"  from_work_dir="output_reverse.txt" label="${tool.name} on ${on_string}: RawData reverse" >
+            <filter>input_type_select['input_type'] == 'paired'</filter>
+        </data>
     </outputs>
     <tests>
         <test expect_num_outputs="2">
@@ -222,26 +228,22 @@
                     </collection>
                 </param>
             </conditional>
-            <output_collection name="html_files">
-                <element name="forward">
-                    <assert_contents>
-                        <has_text text='1000trimmed_forward FastQC Report'/>
-                    </assert_contents>
-                </element>
-                <element name="reverse">
-                    <assert_contents>
-                        <has_text text='1000trimmed_reverse FastQC Report'/>
-                    </assert_contents>
-                </element>
-            </output_collection>
-            <output_collection name="text_files">
-                <element name="forward" value="fastqc_data_forward.txt"/>
-                <element name="reverse">
-                    <assert_contents>
-                    <has_text text="1000trimmed_reverse" />
-                    </assert_contents>
-                </element>
-            </output_collection>
+            <output name="html_file_forward">
+                <assert_contents>
+                    <has_text text='1000trimmed_forward FastQC Report'/>
+                </assert_contents>
+            </output>
+            <output name="html_file_reverse">
+                <assert_contents>
+                    <has_text text='1000trimmed_reverse FastQC Report'/>
+                </assert_contents>
+            </output>
+            <output name="text_file_forward" value="fastqc_data_forward.txt"/>
+            <output name="text_file_reverse">
+                <assert_contents>
+                <has_text text="1000trimmed_reverse" />
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
